### PR TITLE
Fix auto-execution configuration issues

### DIFF
--- a/bot/paper_trading_cli.py
+++ b/bot/paper_trading_cli.py
@@ -125,6 +125,9 @@ def main():
     # Initialize strategy
     strategy = PaperTradingStrategy(config_file=config_file)
     
+    # Store config_file path in strategy instance for later use
+    strategy.config_file = config_file
+    
     # Process commands
     if args.command == 'start':
         if strategy.is_running:

--- a/bot/startup.sh
+++ b/bot/startup.sh
@@ -91,6 +91,10 @@ echo -e "${YELLOW}Creating necessary directories...${NC}"
 mkdir -p logs
 mkdir -p frontend/trading_data
 
+# Configure auto-execution settings
+echo -e "${YELLOW}Configuring auto-execution settings...${NC}"
+python3 paper_trading_cli.py auto-execute --enabled true --confidence 0.75 --interval 300
+
 # Start backend server
 echo -e "${YELLOW}Starting Flask API server...${NC}"
 python paper_trading_api.py > "$BOT_DIR/backend.log" 2>&1 &

--- a/bot/strategies/paper_trading.py
+++ b/bot/strategies/paper_trading.py
@@ -60,15 +60,21 @@ class PaperTradingStrategy:
         except Exception as e:
             logger.error(f"Error loading configuration: {str(e)}")
 
-    def save_config(self, config_file: str) -> None:
+    def save_config(self, config_file: str = None) -> None:
         """Save current configuration to file."""
         try:
-            os.makedirs(os.path.dirname(config_file), exist_ok=True)
-            with open(config_file, 'w') as f:
+            # Use provided config_file or fall back to instance config_file
+            save_file = config_file or getattr(self, 'config_file', None)
+            if not save_file:
+                raise ValueError("No config file path provided")
+                
+            os.makedirs(os.path.dirname(save_file), exist_ok=True)
+            with open(save_file, 'w') as f:
                 json.dump(self.config, f, indent=2)
-            logger.info(f"Saved configuration to {config_file}")
+            logger.info(f"Saved configuration to {save_file}")
         except Exception as e:
             logger.error(f"Error saving configuration: {str(e)}")
+            raise
 
     def update_config(self, config: Dict) -> None:
         """Update configuration settings."""


### PR DESCRIPTION
This PR fixes several issues related to auto-execution configuration:

1. Fixed `save_config()` in `PaperTradingStrategy` to handle missing config_file:
   - Made config_file parameter optional
   - Added fallback to instance config_file path
   - Improved error handling

2. Updated strategy initialization in CLI:
   - Store config_file path in strategy instance
   - Ensures config path is available for all operations

3. Enhanced startup script:
   - Added auto-execution configuration on startup
   - Sets default values for confidence (0.75) and interval (300s)
   - Ensures trading bot starts with consistent settings

4. Added better error handling:
   - Proper error propagation in save_config
   - Clear error messages for configuration issues

Testing:
- Verified auto-execution configuration works via CLI
- Tested startup script auto-configuration
- Confirmed configuration persistence across restarts

Note: This change maintains backward compatibility while fixing the configuration issues that were causing errors in auto-execution setup.